### PR TITLE
Add support for Node v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "webpack-merge": "5.8.0"
       },
       "engines": {
-        "node": "16.x.x"
+        "node": ">=16.x.x <= 18.x.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "engines": {
-    "node": "16.x.x"
+    "node": ">=16.x.x <= 18.x.x"
   },
   "scripts": {
     "test": "ts-mocha -p tsconfig.json test/**/*.spec.ts",

--- a/test/wallet-service.spec.ts
+++ b/test/wallet-service.spec.ts
@@ -2,7 +2,6 @@
 import 'mocha'
 import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
-import 'whatwg-fetch'
 import * as fetchMock from 'fetch-mock'
 import { FetchError } from 'node-fetch'
 


### PR DESCRIPTION
Hi,

For my project, Node's current LTS version is required. Therefore, can there be added support for this?

Tests are passing when removing unused import of package: `whatwg-fetch`.

Many thanks!

Best regards,
Morten